### PR TITLE
Tweaks for custom domains with expired Certificate and fresh hugo installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 # Makefile
 source := main.go
 
+export GO111MODULE = on
+
 pre:
 	mkdir -p ./build/
-	env GO111MODULE=on go get -d ./
+	go get -d ./
 
 build: pre
 	go build -o ./build/binary $(source)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Medium to Hugo 
+# Medium to Hugo
 Tool for the migration of articles from a medium.com account to a static website generator with markdown like Hugo.
 
 Here is a preview from my own migration (from medium to Hugo):
@@ -17,12 +17,14 @@ Here is a preview from my own migration (from medium to Hugo):
 * custom `.Params`: image, images, slug, subtitle
 * minimal HTML cleanup (removed empty URLs, duplicate title and so on)
 
-## Usage 
+## Usage
 
 1. Download your [medium data](https://help.medium.com/hc/en-us/articles/115004745787-Download-your-information)
 2. Unzip it
 3. Download our binary (see Releases)
 4. Run something like `./mediumtohugo /path/to/export/posts /path/to/hugo/content/ posts`
+
+In case you need to bypass TLS/SSL checks you can run the binary with `ALLOW_INSECURE=true` environment variable. This is a case if the medium certificate expires and you want to export your blog with all tags.
 
 
 ### Build / Contribute

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,7 +14,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-	"crypto/tls"
 
 	"github.com/lunny/html2md"
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"crypto/tls"
 
 	"github.com/lunny/html2md"
 
@@ -304,7 +305,13 @@ aliases:
 
 func getTagsFor(url string) ([]string, error) {
 	//TODO make a custom client with a small timeout!
-	res, err := http.Get(url)
+	skipTLS := os.Getenv("ALLOW_INSECURE") == "true"
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLS},
+	}
+	client := &http.Client{Transport: tr}
+
+	res, err := client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,10 @@ func main() {
 	var postsHTMLFolder = os.Args[1]
 
 	// Destination for Markdown files, perhaps the content folder for Hugo or Jekyll
-	var hugoContentFolder = os.Args[2] + "/"
+	var hugoContentFolder = os.Args[2]
+	if !strings.HasSuffix(hugoContentFolder, "/") {
+		hugoContentFolder += "/"
+	}
 
 	var hugoContentType = os.Args[3]
 
@@ -175,7 +178,7 @@ func process(doc *goquery.Document, f os.FileInfo, contentFolder, contentType st
 	pageBundle := prefix + "_" + slug
 	p.HddFolder = fmt.Sprintf("%s%s/%s/", contentFolder, contentType, pageBundle)
 	os.RemoveAll(p.HddFolder) //make sure does not exists
-	err = os.Mkdir(p.HddFolder, os.ModePerm)
+	err = os.MkdirAll(p.HddFolder, os.ModePerm)
 	if err != nil {
 		err = fmt.Errorf("error post folder: %s", err)
 		return

--- a/main.go
+++ b/main.go
@@ -289,11 +289,11 @@ description: "{{ .Description }}"
 
 subtitle: "{{ .Subtitle }}"
 {{ if .Tags }}tags:
-{{ range .Tags }} - {{.}} 
+{{ range .Tags }} - {{.}}
 {{end}}{{end}}
 {{ if .FeaturedImage }}image: "{{.FeaturedImage}}" {{end}}
 {{ if .Images }}images:
-{{ range .Images }} - "{{.}}" 
+{{ range .Images }} - "{{.}}"
 {{end}}{{end}}
 
 aliases:
@@ -305,7 +305,7 @@ aliases:
 
 func getTagsFor(url string) ([]string, error) {
 	//TODO make a custom client with a small timeout!
-	skipTLS := os.Getenv("ALLOW_INSECURE") == "true"
+	skipTLS := strings.ToLower(os.Getenv("ALLOW_INSECURE")) == "true"
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLS},
 	}


### PR DESCRIPTION
I tried to use today the importer but experienced few issues, fixed in this PR:

- Probably initial development was done on older version of Golang, I made the makefile compatible with even newer setups, mine is: `1.12.6` and the `go.mod` file from repository requires compatibility ENV variable. 
- on fresh installations of Hugo in `content/` folder there is not much, yet the program required things like `content/posts` folder structure etc. I made the program ready for situations when it's all brand-new + allowed format of the second attribute which might end with a `/` sign already. Such variant is even suggested in the command help suggestion.
- In my personal situation that forced me to migrate from Medium is because they didn't refreshed my domain certificate. Due to that the program failed to fetch tags for posts. I made an optional disable of the certificate verification with an ENV variable: `ALLOW_INSECURE=true`. Also added this to readme.