### PR TITLE
Improved images handling + tweaks for Tags parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Here is a preview from my own migration (from medium to Hugo):
 * stories are ordered by date (`year-month-day_slug`)
 * custom `.Params`: image, images, slug, subtitle
 * minimal HTML cleanup (removed empty URLs, duplicate title and so on)
+* adds `#layout...` suffix to every image so they can be styles accordingly from plain CSS with exactly same style as on Medium.
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -295,9 +295,10 @@ subtitle: "{{ .Subtitle }}"
 {{ if .Images }}images:
 {{ range .Images }} - "{{.}}"
 {{end}}{{end}}
-
+{{ if .Canonical }}
 aliases:
     - "/{{ .Canonical }}"
+{{end}}
 ---
 
 {{ .Body }}

--- a/main.go
+++ b/main.go
@@ -380,13 +380,19 @@ func fetchAndReplaceImages(doc *goquery.Document, folder, contentType, pageBundl
 }
 
 func extractMediumImageStyle(imgDomElement *goquery.Selection) (mediumImageStyle string) {
-	imageStyles := imgDomElement.ParentsUntil("figure.graf").Parent().AttrOr("class", "")
+	figure := imgDomElement.ParentsUntil("figure.graf").Parent()
+	imageStyles := figure.AttrOr("class", "")
 	rule, _ := regexp.Compile("graf--(layout\\w+)")
 	foundStyles := rule.FindStringSubmatch(imageStyles)
-	mediumImageStyle = "layoutDefault"
+	mediumImageStyle = "layoutTextWidth"
 	if len(foundStyles) > 1 {
 		mediumImageStyle = foundStyles[1]
 	}
+	if strings.HasPrefix(mediumImageStyle, "layoutOutsetRow") { // can also be layoutOutsetRowContinue
+		imagesInRow := figure.Parent().AttrOr("data-paragraph-count", "")
+		mediumImageStyle += imagesInRow
+	}
+	
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -352,9 +352,11 @@ func fetchAndReplaceImages(doc *goquery.Document, folder, contentType, pageBundl
 			return
 		}
 
-		pieces := strings.Split(original, ".")
-		ext := pieces[len(pieces)-1]
-		filename := fmt.Sprintf("%d.%s", index, ext)
+		ext := filepath.Ext(original)
+		if len(ext) == 0 {
+			ext = ".jpg"
+		}
+		filename := fmt.Sprintf("%d%s", index, ext)
 		url := fmt.Sprintf("/%s/%s/images/%s", contentType, pageBundle, filename)
 		diskPath := fmt.Sprintf("%s%s", diskImagesFolder, filename)
 

--- a/main.go
+++ b/main.go
@@ -323,7 +323,7 @@ func getTagsFor(url string) ([]string, error) {
 	}
 	var result []string
 	//fmt.Printf("%s", doc.Text())
-	doc.Find("ul.tags>li>a").Each(func(i int, selection *goquery.Selection) {
+	doc.Find("ul>li>a[href^='/tag']").Each(func(i int, selection *goquery.Selection) {
 		result = append(result, selection.Text())
 	})
 	return result, nil

--- a/main.go
+++ b/main.go
@@ -353,7 +353,7 @@ func fetchAndReplaceImages(doc *goquery.Document, folder, contentType, pageBundl
 		}
 
 		ext := filepath.Ext(original)
-		if len(ext) == 0 {
+		if len(ext) < 2 {
 			ext = ".jpg"
 		}
 		filename := fmt.Sprintf("%d%s", index, ext)
@@ -379,14 +379,15 @@ func fetchAndReplaceImages(doc *goquery.Document, folder, contentType, pageBundl
 	return result, featuredImage, nil
 }
 
+var mediumImageLayout = regexp.MustCompile(`graf--(layout\w+)`)
+
 func extractMediumImageStyle(imgDomElement *goquery.Selection) (mediumImageStyle string) {
 	figure := imgDomElement.ParentsUntil("figure.graf").Parent()
 	imageStyles := figure.AttrOr("class", "")
-	rule, _ := regexp.Compile("graf--(layout\\w+)")
-	foundStyles := rule.FindStringSubmatch(imageStyles)
+	foundImageLayout := mediumImageLayout.FindStringSubmatch(imageStyles)
 	mediumImageStyle = "layoutTextWidth"
-	if len(foundStyles) > 1 {
-		mediumImageStyle = foundStyles[1]
+	if len(foundImageLayout) > 1 {
+		mediumImageStyle = foundImageLayout[1]
 	}
 	if strings.HasPrefix(mediumImageStyle, "layoutOutsetRow") { // can also be layoutOutsetRowContinue
 		imagesInRow := figure.Parent().AttrOr("data-paragraph-count", "")


### PR DESCRIPTION
When importing posts from my medium page I discovered that sometimes links to assets in Medium are not having explicit file extension. But the default for such, since they are imported from [Unsplash](https://unsplash.com), is `.jpg`. So I reorganized the code a bit for that behavior.

Another missing feature related to images and exports from Medium was lack of details how the image was styled in original post. By looking up in Medium code I figured out there are few styles, described in parent `<figure>` tag classes:

* graf--layoutFillWidth
* graf--layoutOutsetCenter
* graf--layoutOutsetLeft
* graf--layoutOutsetRow
* graf--layoutOutsetRowContinue

plus sometimes it's not specified and then it's a regular image with same width as text.

The last two have also some extra details in parent HTML node which says how many images should there appear in a single row and it can vary how the image grid is shown. There is an excellent post that summarize what styles are possible for images on Medium: https://medium.com/@jeffreywang1183/medium-image-guideline-b0e2c4947d90 plus Medium has a support page about it: https://help.medium.com/hc/en-us/articles/215679797-Images 

Based on that research and article about styling images in markdown: https://www.xaprb.com/blog/how-to-style-images-with-markdown/ I decided to add the image layout details to the `<img src="..."/>` attribute value in a form of `#layoutName` meta-information. 

This way CSS rules like:

```css
img[src$="#layoutFillWidth"] {
  // ...
}
```

and similar would allow to style the images accordingly without modifying the markdown and putting there plain HTML tags.

Hope the idea would be liked and will get an approval. 

A complete list of possible suffixed of img-src values is:

* `#layoutTextWidth` - for default situation and when the `graf--layout...` class wasn't specified
* `#layoutFillWidth` - to make the image at width of full width of viewport. How to style it? [Check here](https://medium.com/on-coding/well-actually-full-width-images-with-css-43745e78e1a3). This is also a style of a featured/first image.
* `#layoutOutsetCenter` - centered image a bit wider than text column
* `#layoutOutsetLeft` - positioned on top-left of next paragraph with effect of text wrapped around the image.
* `#layoutOutsetRow2` or `layoutOutsetRowContinue2` - when there are two images in a row. First the the first class second the one with `Continue` word in middle
* `#layoutOutsetRow3` or `layoutOutsetRowContinue3` - similar to previous one, when there are three images in a row. First the the first class second and third the one with `Continue` word in middle.

In case Medium adds some new layouts there will be automatically supported. Thanks to the way that code takes anything what's after `graf--layout` prefix. 