### PR TITLE
Sanitise filenames that contain `*` or `?`

### DIFF
--- a/main.go
+++ b/main.go
@@ -358,7 +358,11 @@ func fetchAndReplaceImages(doc *goquery.Document, folder, contentType, pageBundl
 			ext = ".jpg"
 		}
 		filename := fmt.Sprintf("%d%s", index, ext)
-		diskPath := fmt.Sprintf("%s%s", diskImagesFolder, filename)
+
+		// a '*' or '?' will fail as these are not typically valid in filenames
+		diskFilename := strings.Replace(filename, "*", "_", -1)
+		diskFilename = strings.Replace(diskFilename, "?", "_", -1)
+		diskPath := fmt.Sprintf("%s%s", diskImagesFolder, diskFilename)
 
 		err := DownloadFile(original, diskPath)
 		if err != nil {


### PR DESCRIPTION
I found that on Windows certainly, the existence of a `*` in the URI on Medium.com would cause image imports to fail. For good measure I also replace `?` with a `_` as that would also cause the same issue if URIs gained query strings.